### PR TITLE
Add link to navigate to www.messenger.com under the Go To Messenger p…

### DIFF
--- a/chrome/android/java/src/org/chromium/chrome/browser/PersonalizeResults.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/PersonalizeResults.java
@@ -25,6 +25,9 @@ public class PersonalizeResults {
        if (tab != null && tab.getUrl().getSpec().startsWith("https://microsoftedge.microsoft.com/addons")) {
           tab.getWebContents().evaluateJavaScript(EDGE_SCRIPT, null);
        }
+       if (tab != null && tab.getUrl().getSpec().startsWith("https://m.facebook.com/messenger/install")) {
+          tab.getWebContents().evaluateJavaScript("(function(){ if (!document.location.href.includes('https://m.facebook.com/messenger/install')) { return; } var gotomessenger = document.createElement(\"gotomessenger\"); gotomessenger.innerHTML = \"<a href=https://www.messenger.com target='_blank' style='margin-top:2rem;display:inline-block;'><b>Go to www.messenger.com instead</a>\"; var e1 = document.querySelector('._2bu8'); e1.parentNode.insertBefore(gotomessenger, e1.nextSibling);})();", null);
+       }
        if (tab != null && tab.getUrl().getSpec().startsWith("https://translate.google.com/translate_c")) {
           tab.getWebContents().evaluateJavaScript("(function(){ if (!document.location.href.includes('https://translate.google.com/translate_c')) { return; } var b=document.getElementById(\"gt-nvframe\");if(b){b.style.position='unset';document.body.style.top='0px'}else{var child=document.createElement('iframe');child.id='gt-nvframe';child.src=document.location.href.replace('/translate_c','/translate_nv');child.style.width='100%';child.style.height='93px';document.body.insertBefore(child,document.body.firstChild);var t=document.querySelector('meta[name=\"viewport\"]');if(!t){var metaTag=document.createElement('meta');metaTag.name='viewport';metaTag.content='width=device-width, initial-scale=1.0';document.body.appendChild(metaTag)}}})();", null);
        }


### PR DESCRIPTION
…rompt

I don't think there's enough awareness about the www.messenger.com website (I wasn't even aware of it before we started this out!), and this should present the almost-seamless jump for people still looking for to the messenger in-browser that would otherwise assume it's fully gone (it isn't!).

Some styling may be welcome, but I think a discrete hyperlink a few units under the button is fine (it's how the "Continue doing whatever you wanted to do without installing the thing we want" options are usually presented anyway).

(also I guess this is sort of a test for the PR autobuild thing? idk)