### PR TITLE
Change cursor attribute on KaiOS FB to default

### DIFF
--- a/chrome/android/java/src/org/chromium/chrome/browser/PersonalizeResults.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/PersonalizeResults.java
@@ -28,6 +28,9 @@ public class PersonalizeResults {
                        || tab.getUrl().getSpec().startsWith("https://m.facebook.com/messages"))) {
           tab.getWebContents().evaluateJavaScript(MESSENGER_SCRIPT, null);
        }
+       if (tab != null && tab.getUrl().getSpec().startsWith("https://m.facebook.com/")) {
+          tab.getWebContents().evaluateJavaScript("(function(){ document.querySelector('body.touch').style = \"cursor:default\";})();", null);
+       }
        if (tab != null && tab.getUrl().getSpec().startsWith("https://translate.google.com/translate_c")) {
           tab.getWebContents().evaluateJavaScript("(function(){ var b=document.getElementById(\"gt-nvframe\");if(b){b.style.position='unset';document.body.style.top='0px'}else{var child=document.createElement('iframe');child.id='gt-nvframe';child.src=document.location.href.replace('/translate_c','/translate_nv');child.style.width='100%';child.style.height='93px';document.body.insertBefore(child,document.body.firstChild);var t=document.querySelector('meta[name=\"viewport\"]');if(!t){var metaTag=document.createElement('meta');metaTag.name='viewport';metaTag.content='width=device-width, initial-scale=1.0';document.body.appendChild(metaTag)}}})();", null);
        }


### PR DESCRIPTION
For some reason it's always on pointer mode on KaiOS FB which causes Kiwi to show blue flashes whenever you tap on empty spaces.