### PR TITLE
Fix kiwi://extensions on small screens

### DIFF
--- a/chrome/browser/resources/extensions/item.html
+++ b/chrome/browser/resources/extensions/item.html
@@ -44,6 +44,8 @@
     display: flex;
     flex-direction: column;
     height: var(--extensions-card-height);
+    /* Card can not we wider than the screen size. */
+    max-width: 100vw;
     /* Duration matches --drawer-transition from toolbar.html. */
     transition: height 300ms cubic-bezier(.25, .1, .25, 1);
   }

--- a/chrome/browser/resources/extensions/item_list.html
+++ b/chrome/browser/resources/extensions/item_list.html
@@ -34,7 +34,8 @@
     display: grid;
     grid-column-gap: var(--grid-gutter);
     grid-row-gap: var(--grid-gutter);
-    grid-template-columns: repeat(auto-fill, var(--extensions-card-width));
+    /* Grid column width can not be larger than screen width. */
+    grid-template-columns: repeat(auto-fill, min(var(--extensions-card-width), 100vw));
     justify-content: center;
     margin: auto;
     max-width: calc(var(--extensions-card-width) * var(--max-columns) +

--- a/chrome/browser/resources/extensions/toolbar.html
+++ b/chrome/browser/resources/extensions/toolbar.html
@@ -68,6 +68,13 @@
     --cr-toolbar-field-max-width: var(--cr-toolbar-center-basis);
     --cr-toolbar-field-width: 100%;
   }
+
+  /* On small screens hide the toggle label so to live space for toggle itself. */
+  @media (max-width: 400px) {
+    #devModeLabel {
+      display: none;
+    }
+  }
 </style>
 <cr-toolbar page-name="$i18n{toolbarTitle}" search-prompt="$i18n{search}"
     clear-label="$i18n{clearSearch}" menu-label="$i18n{mainMenu}" show-menu


### PR DESCRIPTION
**This was not tested on real build yet (waiting for CI)**

This PR fixes visual issues of `kiwi://extensions` on small screens (less than 400 virtual pixels):
 - the developer toggle is not visible because the label itself takes its place
   There was a way to access the toggle, but it was not intuitive (click on "search" icon to hide page label, then hold and swipe the toggle).
 - the extension cards are too wide and do not fit the screen

### Before
Screenshot made on Kiwi 105.0.5195.33 on Samsung Galaxy S20 FE:
![Screenshot_20221014-175700_Kiwi Browser](https://user-images.githubusercontent.com/45960703/195879041-1371a8f6-a9f4-4bea-ac8b-068bab1e30ea.jpg)

### After:
Screenshot made on Chromium on PC (real Kiwi screenshot coming later):
![image](https://user-images.githubusercontent.com/45960703/195878984-337be582-3e8d-4894-8a70-462abce5c418.png)
