### PR TITLE
Enable is_high_end_android

### DIFF
--- a/.build/production_build_reference/args.gn
+++ b/.build/production_build_reference/args.gn
@@ -47,3 +47,5 @@ treat_warnings_as_errors = false
 
 # Fast APK
 cc_wrapper = "ccache"
+
+is_high_end_android = true


### PR DESCRIPTION
Improves Speedometer 2.0 scores on Chromium 117 from 44.8 to 77.1, a whopping 70% performance improvement, all while having smaller binary size (227mb -> 203mb).

Note that this enables relr, which is only supported on API 28 and up. Furthermore, PGO profiles must be fetched as mentioned on https://chromium.googlesource.com/chromium/src.git/+/master/docs/pgo.md